### PR TITLE
Docker compose corrections

### DIFF
--- a/expressjs/.database.env.template
+++ b/expressjs/.database.env.template
@@ -1,3 +1,2 @@
-POSTGRES_DB=safeplaces_development
-POSTGRES_USER=safeplaces
-POSTGRES_PASSWORD=password
+POSTGRES_DB=spdev
+POSTGRES_PASSWORD=safepaths

--- a/expressjs/.env.template
+++ b/expressjs/.env.template
@@ -1,4 +1,7 @@
 NODE_ENV=development
 JWT_SECRET='testtokenforsecurity'
 PORT=3000
-DATABASE_URL=postgres://safeplaces:password@db/safeplaces_development
+DB_HOST=database
+DB_PASS=safepaths
+DB_USER=postgres
+DB_NAME=spdev

--- a/expressjs/Dockerfile
+++ b/expressjs/Dockerfile
@@ -9,5 +9,6 @@ COPY --from=build-env /app /app
 WORKDIR /app
 ADD wait-for.sh /wait-for.sh
 RUN npm install -g knex
-CMD npm start
+ENTRYPOINT ["/app/dbsetup.sh"]
+CMD ["npm", "start"]
 

--- a/expressjs/Dockerfile
+++ b/expressjs/Dockerfile
@@ -6,8 +6,8 @@ RUN npm install
 
 FROM node:13.13.0
 COPY --from=build-env /app /app 
+WORKDIR /app
 ADD wait-for.sh /wait-for.sh
 RUN npm install -g knex
-ENTRYPOINT ["/app/dbsetup.sh"]
-CMD ["npm", "start"]
+CMD npm start
 

--- a/expressjs/README.md
+++ b/expressjs/README.md
@@ -1,4 +1,7 @@
+
 # Example NodeJS Postgres DB based backend for Safeplaces API
+
+  
 
   
 
@@ -6,7 +9,11 @@
 
   
 
+  
+
 ### Deploy in local machine
+
+  
 
   
 
@@ -14,15 +21,25 @@
 
   
 
+  
+
 Clone this repository
+
+  
 
   
 
 ```
 
+  
+
 cd safeplaces-backend
 
+  
+
 ```
+
+  
 
   
 
@@ -30,21 +47,37 @@ cd safeplaces-backend
 
   
 
+  
+
 Steps to install NVM are documented [in the nvm repository](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+  
 
 Install npm using nvm
 
   
 
+  
+
 ```
+
+  
 
 nvm install 13.1.0
 
+  
+
 nvm use 13.1.0
+
+  
 
 npm install
 
+  
+
 ```
+
+  
 
   
 
@@ -52,15 +85,25 @@ npm install
 
   
 
+  
+
 Install Knex globally
+
+  
 
   
 
 ```
 
+  
+
 npm install knex -g
 
+  
+
 ```
+
+  
 
   
 
@@ -68,13 +111,23 @@ Run migrations
 
   
 
+  
+
 ```
+
+  
 
 knex migrate:latest --env test
 
+  
+
 knex migrate:latest --env development
 
+  
+
 ```
+
+  
 
   
 
@@ -82,13 +135,23 @@ Seed the database
 
   
 
+  
+
 ```
+
+  
 
 knex seed:run --env test
 
+  
+
 knex seed:run --env development
 
+  
+
 ```
+
+  
 
   
 
@@ -96,15 +159,25 @@ knex seed:run --env development
 
   
 
+  
+
 Install mocha globally.
+
+  
 
   
 
 ```
 
+  
+
 npm install mocha -g
 
+  
+
 ```
+
+  
 
   
 
@@ -112,11 +185,19 @@ Run testing through mocha to see if unit tests pass
 
   
 
+  
+
 ```
+
+  
 
 mocha
 
+  
+
 ```
+
+  
 
   
 
@@ -126,45 +207,64 @@ mocha
 
 *Note*: The installation assumes you have already installed Postgres DB in your local environment listening for connections at port 5432. Your Postgres instance should listen to '*' instead of 'localhost', this setting can be found in your pgconfig file.
 
-  
+ 
 
 Clone this repository
 
   
 
-```
-
-cd safeplaces-backend
-
-```
-
   
+
+
 
 #### Build Dockerfile
 
   
 
-```
-
-docker build -t <docker_repo>/safeplaces-backend-expressjs .
+  
 
 ```
 
   
 
+docker build -t safeplaces-backend-expressjs .
+
+  
+
+```
+
+  
+
+  
+
 #### Run Dockerfile
+
 ```
-docker run --env-file=end -p 3000:3000 <docker_repo>/safeplaces-backend-expressjs
+
+docker run --rm --name safeplaces-expressjs --env-file=.env -p 3000:3000 safeplaces-backend-expressjs
+
 ```
+
+  
 
 *Note*: sample env file can be found at .env.template`.
 
-#### Deploy via  docker-compose
-```
-Ensure to create env file .env from .env.template for Application Environment Variables
-Ensure to create env file .backend.env from .backend.env.template for Postgres Environment variables
+  
+
+#### Deploy via docker-compose
+
+
+ *Using docker-compose will bring a postgres server along with the application container* 
+ 
+Ensure to create application Environment variables  file .env from .env.template
+
+Ensure to create Postgres Environment variables file  .backend.env from .backend.env.template 
+
 ```
 
-    docker-compose build
-    docker-compose up
+#### Run the following:
 
+docker-compose build
+docker-compose up
+
+Test your deployment via `curl http://127.0.0.1:3000/health`

--- a/expressjs/db/migrations/20200420011121_update_ts.js
+++ b/expressjs/db/migrations/20200420011121_update_ts.js
@@ -8,7 +8,7 @@ const ON_UPDATE_TIMESTAMP_FUNCTION = `
 $$ language 'plpgsql';
 `;
 
-const DROP_ON_UPDATE_TIMESTAMP_FUNCTION = `DROP FUNCTION on_update_timestamp`
+const DROP_ON_UPDATE_TIMESTAMP_FUNCTION = `DROP FUNCTION on_update_timestamp`;
 
 exports.up = knex => knex.raw(ON_UPDATE_TIMESTAMP_FUNCTION);
 exports.down = knex => knex.raw(DROP_ON_UPDATE_TIMESTAMP_FUNCTION);

--- a/expressjs/dbsetup.sh
+++ b/expressjs/dbsetup.sh
@@ -4,3 +4,5 @@ knex --knexfile /app/knexfile.js migrate:latest --env development
 
 # knex --knexfile /app/knexfile.js seed:run --env test
 knex --knexfile /app/knexfile.js seed:run --env development
+
+exec "$@"

--- a/expressjs/docker-compose.yml
+++ b/expressjs/docker-compose.yml
@@ -15,7 +15,23 @@ services:
       - node_modules:/app/node_modules
     networks:
       - app-network
+    depends_on:
+      - db
+      - migration
     command: ./wait-for.sh db:5432 -- npm start 
+
+  migration:
+    image: safe-places-server_safeplaces:latest
+    container_name: migration
+    env_file: .env
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    networks:
+      - app-network
+    depends_on:
+      - db
+    command: ./wait-for.sh db:5432 -- /app/dbsetup.sh
 
   db:
     image: postgres:12.2

--- a/expressjs/docker-compose.yml
+++ b/expressjs/docker-compose.yml
@@ -3,49 +3,33 @@ services:
   safeplaces:
     build:
       context: .
-      # dockerfile: Dockerfile
-      # image: nodejs
     container_name: safeplaces
-    restart: unless-stopped
+    #restart: unless-stopped
     env_file: .env
     ports:
-      - "80:3000"
+      - "3000:3000"
     volumes:
       - .:/app
       - node_modules:/app/node_modules
     networks:
-      - app-network
+      - safeplace
     depends_on:
       - db
-      - migration
-    command: ./wait-for.sh db:5432 -- npm start 
-
-  migration:
-    image: safe-places-server_safeplaces:latest
-    container_name: migration
-    env_file: .env
-    volumes:
-      - .:/app
-      - node_modules:/app/node_modules
-    networks:
-      - app-network
-    depends_on:
-      - db
-    command: ./wait-for.sh db:5432 -- /app/dbsetup.sh
-
   db:
-    image: postgres:12.2
+    image: postgres:12.1
     container_name: database
     env_file:
       - .database.env
     volumes:
-      - database-data:/var/lib/postgresql/data/
+      - dbdata:/var/lib/postgresql/data/
+    ports:
+      - "5432"
     networks:
-      - app-network  
+      - safeplace
 networks:
-  app-network:
-    driver: bridge
+  safeplace:
+     driver: bridge
 
 volumes:
-  database-data:
+  dbdata:
   node_modules:  

--- a/expressjs/knexfile.js
+++ b/expressjs/knexfile.js
@@ -2,7 +2,12 @@
 module.exports = {
   test: {
     client: 'pg',
-    connection: process.env.DATABASE_URL,
+    connection: {
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASS,
+      database: process.env.DB_NAME
+          },
     migrations: {
       directory: __dirname + '/db/migrations'
     },
@@ -12,7 +17,12 @@ module.exports = {
   },
   development: {
     client: 'pg',
-    connection: process.env.DATABASE_URL,
+    connection: {
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASS,
+      database: process.env.DB_NAME
+          },
     migrations: {
       directory: __dirname + '/db/migrations'
     },
@@ -22,8 +32,12 @@ module.exports = {
   },
   production: {
     client: 'pg',
-    connection: process.env.DATABASE_URL,
-    migrations: {
+    connection: {
+        host: process.env.DB_HOST,
+        user: process.env.DB_USER,
+        password: process.env.DB_PASS,
+        database: process.env.DB_NAME
+      }, migrations: {
       directory: __dirname + '/db/migrations'
     },
     seeds: {


### PR DESCRIPTION
Docker-compose installation was failing to start the node app just after running the migrations. This was due to the migration step being defined in ENTRYPOINT.
If we combine CMD and ENTRYPOINT, the params in CMD are treated as params to ENTRYPOINT.

For eg.
ENTRYPOINT ['some_script.sh']
CMD ['second_script.sh', 'param1']

Would result in `some_script.sh second_script.sh param1`.

An alternative would be to define everything in either of CMD or ENTRYPOINT with the form:
`CMD some_script.sh && second_script.sh param1`

Though it is recommended that migrations need to be a separate step to decouple app start and migrations.

TODOs:
Make sure connections to `db:5432` work. The `wait-for-it.sh` script is timing out.