### PR TITLE
Project status added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ This repository holds example backends for [Safeplaces API specification](https:
 Safeplaces is a toolkit for public health, built on top of data shared by users of [Private Kit](https://github.com/tripleblindmarket/covid-safe-paths).
 
 [Safeplaces Frontend](https://github.com/Path-Check/safeplaces-frontend) is an example client for these backends.
+
+## Project Status
+
+[![Project Status: WIP – The project is still under development and will reach a Minimum Viable Product stage soon.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+
+The project is still under development and will reach a Minimum Viable Product (MVP) stage soon.  
+*Note*: There can be breaking changes to the developing code until the MVP is released.


### PR DESCRIPTION
Addresses Partially: Path-Check/safeplaces-frontend#53

GitHub batches are GitHub's way of expressing Project Status for its repos.

Repostatus Batch is suitable for our purpose of showing the project's status.
https://www.repostatus.org/