### PR TITLE
Extract LDAP environment variables and document usage

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,3 +12,7 @@ GOOGLE_CLOUD_PROJECT=something
 GCLOUD_STORAGE_BUCKET=somethingOrOther
 LDAP_HOST=localhost
 LDAP_PORT=1389
+LDAP_PASS=safepaths
+LDAP_ORG='dc=covidsafepaths,dc=org'
+LDAP_BIND='cn=admin'
+LDAP_FILTER='(&(cn={{username}})(password={{password}}))'

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 .idea/
 .vscode/
 
-.DS_Store
-
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -58,7 +58,26 @@ Refer [.env.template](.env.template) for environment variables to be exported to
 The basic, included LDAP server is to be used for testing purposes only.
 It is not meant for production use.
 
-Please see the OpenLDAP implementations for production-ready servers.
+Please see the OpenLDAP implementations for production-ready servers. Once set up, modify the environment
+variables to point to the new server, with the proper host, port, password, domain components, and bind command.
+
+Example:
+```
+LDAP_HOST=localhost
+LDAP_PORT=1389
+LDAP_PASS=safepaths
+LDAP_ORG='dc=covidsafepaths,dc=org'
+LDAP_BIND='cn=admin'
+```
+
+The Express server queries the LDAP server with each login request at `/login`.
+
+The filter will look like
+`(&(cn={{username}})(password={{password}}))`
+
+Note that `{{username}}` and `{{password}}` are **explicitly required.**
+`{{username}}` will be replaced by the username sent by the client's request.
+`{{password}}` will be replaced by the password sent by the client's request.
 
 To run the server:
 ```


### PR DESCRIPTION
This resolves the backend implementation of [PLACES-281](https://pathcheck.atlassian.net/browse/PLACES-281).

See the OpenLDAP implementations for production-ready servers. Once set up, modify the environment variables to point to the new server, with the proper host, port, password, domain components, and bind command.

**Environment variables example:**
```
LDAP_HOST=localhost
LDAP_PORT=1389
LDAP_PASS=safepaths
LDAP_ORG='dc=covidsafepaths,dc=org'
LDAP_BIND='cn=admin'
LDAP_FILTER='(&(cn={{username}})(password={{password}}))'
```

The Express server queries the LDAP server with each login request at `/login`.

The filter will look like
`(&(cn={{username}})(password={{password}}))`

Note that `{{username}}` and `{{password}}` are **explicitly required.**
`{{username}}` will be replaced by the username sent by the client's request.
`{{password}}` will be replaced by the password sent by the client's request.
