### PR TITLE
Modify LDAP environment variables to ensure compat with OpenLDAP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,6 @@ GCLOUD_STORAGE_BUCKET=somethingOrOther
 LDAP_HOST=localhost
 LDAP_PORT=1389
 LDAP_PASS=safepaths
-LDAP_ORG='dc=covidsafepaths,dc=org'
-LDAP_BIND='cn=admin'
-LDAP_FILTER='(&(cn={{username}})(password={{password}}))'
+LDAP_ORG="dc=covidsafepaths, dc=org"
+LDAP_BIND="cn=admin, dc=covidsafepaths, dc=org"
+LDAP_FILTER="(&(cn={{username}})(password={{password}}))"

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Example:
 LDAP_HOST=localhost
 LDAP_PORT=1389
 LDAP_PASS=safepaths
-LDAP_ORG='dc=covidsafepaths,dc=org'
-LDAP_BIND='cn=admin'
+LDAP_ORG="dc=covidsafepaths, dc=org"
+LDAP_BIND="cn=admin, dc=covidsafepaths, dc=org"
+LDAP_FILTER="(&(cn={{username}})(password={{password}}))"
 ```
 
 The Express server queries the LDAP server with each login request at `/login`.


### PR DESCRIPTION
This fixes the OpenLDAP environment variable issue.

The single change in the environment variable modifies the `BIND` to use the fully qualified DN.