### PR TITLE
PLACES-301 Cannot PUT organization configuration

### DIFF
--- a/db/models/organizations.js
+++ b/db/models/organizations.js
@@ -84,10 +84,18 @@ class Service extends BaseService {
     if (!id) throw new Error('Organization ID was not valid');
     if (!params) throw new Error('Params were not valid');
 
-    const results = await this.updateOne(id, params)
-    if (results) {
-      return this.fetchById(id)
+    const mappedParams = this._reverseMap(params);
+    const orgResults = await this.updateOne(id, _.pick(mappedParams, ['name', 'completed_onboarding']));
+
+    if (orgResults) {
+      const paramsSettings = _.omit(mappedParams, ['name', 'completed_onboarding']);
+      const settingsResults = await settingsService.updateByOrganizationId(id, paramsSettings);
+
+      if (settingsResults) {
+        return await this.fetchById(id)
+      }
     }
+
     throw new Error('Internal server errror.')
   }
 
@@ -147,6 +155,32 @@ class Service extends BaseService {
         daysToRetainRecords: itm.days_to_retain_records,
         completedOnboarding: itm.completed_onboarding
       }
+   }
+
+
+   /**
+   * Map camelcase params to snakecase
+   *
+   * @private
+   * @method _reverseMap
+   * @param {Object}
+   * @return {Object}
+   */
+
+   _reverseMap(itm) {
+     return {
+       name: itm.name,
+       info_website_url: itm.infoWebsiteUrl,
+       reference_website_url: itm.referenceWebsiteUrl,
+       api_endpoint_url: itm.apiEndpointUrl,
+       privacy_policy_url: itm.privacyPolicyUrl,
+       region_coordinates: itm.regionCoordinates,
+       notification_threshold_percent: itm.notificationThresholdPercent,
+       notification_threshold_count: itm.notificationThresholdCount,
+       chunking_in_seconds: itm.chunkingInSeconds,
+       days_to_retain_records: itm.daysToRetainRecords,
+       completed_onboarding: itm.completedOnboarding
+     }
    }
 }
 

--- a/db/models/settings.js
+++ b/db/models/settings.js
@@ -1,7 +1,20 @@
 const BaseService = require('../common/service.js');
 
 class Service extends BaseService {
+  async updateByOrganizationId(organization_id, params) {
+    if (!organization_id) throw new Error('Organization ID was not valid');
+    if (!params) throw new Error('Params were not valid');
 
+    const settings = await this.table.where({ organization_id: organization_id }).returning('id').first();
+
+    if (settings) {
+      const result = await this.updateOne(settings.id, params);
+
+      if (result) {
+        return result
+      }
+    }
+  }
 }
 
 module.exports = new Service('settings');

--- a/test/integration/organizations.test.js
+++ b/test/integration/organizations.test.js
@@ -78,7 +78,19 @@ describe('Organization ', () => {
 
     it('update the record', async () => {
       const newParams = {
-        name: 'My New Example Name',
+        name: "Some Health Authority",
+        notificationThresholdPercent: 66,
+        notificationThresholdCount: 6,
+        daysToRetainRecords: 14,
+        regionCoordinates: {
+          ne: { "latitude": 20.312764055951195, "longitude": -70.45445121262883},
+          sw: { "latitude": 17.766025040122642, "longitude": -75.49442923997258}
+        },
+        apiEndpointUrl: "https://s3.aws.com/bucket_name/safepaths.json",
+        referenceWebsiteUrl: "http://cdc.gov",
+        infoWebsiteUrl: "http://cdc.gov",
+        privacyPolicyUrl: "https://superprivate.com",
+        completedOnboarding: true
       };
 
       const results = await chai
@@ -91,14 +103,14 @@ describe('Organization ', () => {
       results.should.have.status(200);
       results.body.should.be.a('object');
       results.body.name.should.equal(newParams.name);
-      results.body.infoWebsiteUrl.should.equal(currentOrg.infoWebsiteUrl);
-      results.body.referenceWebsiteUrl.should.equal(currentOrg.referenceWebsiteUrl);
-      results.body.apiEndpointUrl.should.equal(currentOrg.apiEndpointUrl);
-      results.body.notificationThresholdPercent.should.equal(currentOrg.notificationThresholdPercent);
-      results.body.notificationThresholdCount.should.equal(currentOrg.notificationThresholdCount);
-      results.body.daysToRetainRecords.should.equal(currentOrg.daysToRetainRecords);
-      results.body.privacyPolicyUrl.should.equal(currentOrg.privacyPolicyUrl);
-      results.body.completedOnboarding.should.equal(false);
+      results.body.infoWebsiteUrl.should.equal(newParams.infoWebsiteUrl);
+      results.body.referenceWebsiteUrl.should.equal(newParams.referenceWebsiteUrl);
+      results.body.apiEndpointUrl.should.equal(newParams.apiEndpointUrl);
+      results.body.notificationThresholdPercent.should.equal(newParams.notificationThresholdPercent);
+      results.body.notificationThresholdCount.should.equal(newParams.notificationThresholdCount);
+      results.body.daysToRetainRecords.should.equal(newParams.daysToRetainRecords);
+      results.body.privacyPolicyUrl.should.equal(newParams.privacyPolicyUrl);
+      results.body.completedOnboarding.should.equal(newParams.completedOnboarding);
     });
 
     it('fetch the organizations cases', async () => {


### PR DESCRIPTION
The request was failing because need to map the params in the payload from snake case to camel case. I also discovered that we need to partition the params and update the organization its associated settings record in two separate db calls.