### PR TITLE
PLACES-315 Remove invalid check from 

### DIFF
--- a/app/api/case/controller.js
+++ b/app/api/case/controller.js
@@ -76,7 +76,7 @@ exports.ingestUploadedPoints = async (req, res) => {
   const accessCode = await accessCodesService.find({ value: codeValue });
 
   // Check access code validity
-  if (!accessCode || !accessCode.valid) {
+  if (!accessCode) {
     res.status(403).send();
     return;
   }

--- a/app/api/organization/controller.js
+++ b/app/api/organization/controller.js
@@ -146,13 +146,13 @@ exports.createOrganizationCase = async (req, res) => {
 exports.deleteOrganizationCase = async (req, res) => {
   const {
     user: { organization_id },
-    body: { case_id }
+    body: { caseId }
   } = req;
 
   if (!organization_id) throw new Error('Organization ID is missing.');
-  if (!case_id) throw new Error('Case ID is missing.');
+  if (!caseId) throw new Error('Case ID is missing.');
 
-  const results = await organizations.deleteCase(organization_id, case_id);
+  const results = await organizations.deleteCase(organization_id, caseId);
   if (results) {
     res.sendStatus(200);
   } else {

--- a/test/integration/organizations.test.js
+++ b/test/integration/organizations.test.js
@@ -172,7 +172,7 @@ describe('Organization ', () => {
 
     it('delete the record', async () => {
       const newParams = {
-        case_id: caseToDelete.caseId,
+        caseId: caseToDelete.caseId,
       };
 
       const results = await chai

--- a/test/integration/upload.test.js
+++ b/test/integration/upload.test.js
@@ -124,6 +124,7 @@ describe('POST /case/points', () => {
 
     const currentCase = await mockData.mockCase({
       organization_id: currentOrg.id,
+      invalidated_at: new Date("2020-06-02T18:25:43.000Z"),
       state: 'unpublished',
     });
 


### PR DESCRIPTION
We invalidate an access code after a successful upload occurs in the ingestion API but return a 403 from the POST /organization/case endpoint if the access code provided is invalid. This creates a scenario where the points that were successfully imported to the public database will never be imported into the private database. 

Checking the the access code exists and that the user has consented to upload should be sufficient.