### PR TITLE
PLACES-344 move all GET requests that have a body to POST requests

### DIFF
--- a/app/api/case/router.js
+++ b/app/api/case/router.js
@@ -3,18 +3,18 @@
 const server = require('../../../src/server');
 const controller = require('./controller');
 
-server.get(
+server.post(
   '/case/points',
   server.wrapAsync(async (req, res) => await controller.fetchCasePoints(req, res), true),
 );
 
-server.get(
+server.post(
   '/cases/points',
   server.wrapAsync(async (req, res) => await controller.fetchCasesPoints(req, res), true),
 );
 
 server.post(
-  '/case/points',
+  '/case/points/ingest',
   server.wrapAsync(async (req, res) => await controller.ingestUploadedPoints(req, res), true),
 );
 

--- a/app/api/organization/router.js
+++ b/app/api/organization/router.js
@@ -40,7 +40,8 @@ server.get(
     true,
   ),
 );
-server.delete(
+
+server.post(
   '/organization/case',
   server.wrapAsync(
     async (req, res) => await controller.deleteOrganizationCase(req, res),

--- a/oas3.yaml
+++ b/oas3.yaml
@@ -83,10 +83,10 @@ components:
           $ref : '#/components/schemas/timeString'
     caseIds:
       type : object
-      properties: 
+      properties:
         caseIds:
           type: array
-          items: 
+          items:
             $ref : '#/components/schemas/caseId'
           example:
             - 12
@@ -113,13 +113,13 @@ components:
     concernPointDBAdd:
       type: object
       properties:
-        longitude: 
+        longitude:
           type : number
           example: 14.91328448
         latitude:
           type : number
           example: 41.24060321
-        time : 
+        time :
           $ref : '#/components/schemas/timeString'
     concernPointDb:
       type: object
@@ -127,16 +127,16 @@ components:
         pointId:
           type: number
           example: 12
-        longitude: 
+        longitude:
           type : number
           example: 14.91328448
         latitude:
           type : number
           example: 41.24060321
-        time : 
+        time :
           type : string
           example: "2020-05-30T18:25:43.511Z"
-    concernPointApp: 
+    concernPointApp:
       type: object
       properties:
         longitude:
@@ -158,7 +158,7 @@ components:
     consent:
       type: object
       properties:
-        consent : 
+        consent :
           type: boolean
           example: true
         accessCode:
@@ -239,13 +239,13 @@ components:
           $ref: '#/components/schemas/coordinates'
       example:
         value:
-          { "ne": { "latitude": 20.312764055951195, "longitude": -70.45445121262883}, 
+          { "ne": { "latitude": 20.312764055951195, "longitude": -70.45445121262883},
             "sw": { "latitude": 17.766025040122642, "longitude": -75.49442923997258}
           }
     timeString:
       type: string
       example: "2020-05-30T18:25:43.511Z"
-    token: 
+    token:
       type: object
       properties:
         token:
@@ -255,20 +255,20 @@ components:
     uploadId:
       type: object
       properties:
-        uploadId: 
+        uploadId:
           type: string
           example: "42963a2f-9bd8-4ade-a713-3106020c1942"
     valid:
       type: object
       properties:
-        valid : 
+        valid :
           type: boolean
           example: true
 
   examples:
     concernPoints:
-      value: {  
-                "concernPoints" : 
+      value: {
+                "concernPoints" :
               [  {"pointId": 232, "time":"2020-05-30T18:25:43.511Z","longitude":-0.10753902581515137,"latitude":51.55987524514395},
                 {"pointId": 233, "time":"2020-05-30T18:25:43.511Z","longitude":-0.06407687379643874,"latitude":51.53626227398831},
                 {"pointId": 234, "time":"2020-05-30T18:25:43.511Z","longitude":-0.10383699531844902,"latitude":51.5687569927817},
@@ -279,7 +279,7 @@ components:
                 {"pointId": 239, "time":"2020-05-30T18:25:43.511Z","longitude":-0.12014169804782877,"latitude":51.54859663929235}
               ]}
     casesList:
-      value: 
+      value:
         {
           "cases": [
                     {
@@ -349,7 +349,7 @@ paths:
             schema:
               type: object
               properties:
-                accessCode : 
+                accessCode :
                   $ref : '#/components/schemas/authCode'
       responses:
         '200':
@@ -363,7 +363,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
-          $ref: '#/components/responses/InternalServerError' 
+          $ref: '#/components/responses/InternalServerError'
   /consent:
     post:
       summary: Logs user consent to health authority’s terms of service. Invalidates the accessCode that is passed in the payload if  consent  is false.
@@ -380,7 +380,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
-          $ref: '#/components/responses/InternalServerError' 
+          $ref: '#/components/responses/InternalServerError'
   /upload:
     post:
       summary: Accepts SAFE PATHS data upload from the user. Access code sent in body must match an access code created in a POST /access-code call. The uploadId returned may be used by clients to purge data from this upload at a later time.
@@ -442,7 +442,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  accessCode: 
+                  accessCode:
                     $ref: '#/components/schemas/authCode'
         '400':
           $ref: '#/components/responses/InvalidRequest'
@@ -469,7 +469,7 @@ paths:
                     $ref : '#/components/schemas/orgId'
                   name:
                     $ref : '#/components/schemas/orgName'
-                  completeOnBoarding: 
+                  completeOnBoarding:
                     $ref : '#/components/schemas/orgCompleteOnboarding'
         '400':
           $ref: '#/components/responses/InvalidRequest'
@@ -485,7 +485,7 @@ paths:
     get:
       summary: Returns the configuration of the organization associated with the requesting user.
       responses:
-        '200': 
+        '200':
           description: OK
           content:
             application/json:
@@ -496,7 +496,7 @@ paths:
         '403':
           $ref: '#/components/responses/UnauthorizedError'
         '500':
-          $ref: '#/components/responses/InternalServerError'      
+          $ref: '#/components/responses/InternalServerError'
       security:
         - contactTracer: []
         - admin: []
@@ -508,7 +508,7 @@ paths:
             schema:
               $ref: '#/components/schemas/orgConfiguration'
       responses:
-        '200': 
+        '200':
           description: OK
           content:
             application/json:
@@ -519,7 +519,7 @@ paths:
         - admin: []
 
   '/organization/cases':
-    get:
+    post:
       description: Gets a list of case records for the organization
       responses:
         '200':
@@ -573,7 +573,7 @@ paths:
             schema:
               type: object
               properties:
-                caseId: 
+                caseId:
                   $ref: '#/components/schemas/caseId'
                 externalId:
                   $ref : '#/components/schemas/externalId'
@@ -593,8 +593,8 @@ paths:
       security:
         - contactTracer: []
         - admin: []
-              
-    delete:
+
+    post:
       summary: Delete case record
       requestBody:
         content:
@@ -602,7 +602,7 @@ paths:
             schema:
               type: object
               properties:
-                caseId: 
+                caseId:
                   $ref: '#/components/schemas/caseId'
       responses:
         '200':
@@ -612,13 +612,13 @@ paths:
         '403':
           $ref: '#/components/responses/UnauthorizedError'
         '500':
-          $ref: '#/components/responses/InternalServerError'        
+          $ref: '#/components/responses/InternalServerError'
       security:
         - contactTracer: []
         - admin: []
-  
+
   '/case/points':
-    get:
+    post:
       summary: Returns all points of concern for the provided case.
       requestBody:
         content:
@@ -626,7 +626,7 @@ paths:
             schema:
               type: object
               properties:
-                caseId: 
+                caseId:
                   $ref: '#/components/schemas/caseId'
       responses:
         '200':
@@ -639,7 +639,7 @@ paths:
                   concernPoints:
                     $ref: '#/components/schemas/concernPointDb'
               examples:
-                one: 
+                one:
                   $ref : '#/components/examples/concernPoints'
         '400':
           $ref: '#/components/responses/InvalidRequest'
@@ -704,7 +704,7 @@ paths:
       responses:
         '200':
           description: Patient case updated
-          content: 
+          content:
             application/json:
               schema:
                 type: object
@@ -729,10 +729,10 @@ paths:
             schema:
               type: object
               properties:
-                caseId: 
+                caseId:
                   $ref: '#/components/schemas/caseId'
       responses:
-        '200': 
+        '200':
           description: OK
           content:
             appliation/json:
@@ -750,7 +750,7 @@ paths:
       security:
       - contactTracer: []
       - admin: []
-                
+
   '/case/stage':
     post:
       summary: Updates the state of the case from unpublished to staging.
@@ -807,7 +807,7 @@ paths:
       security:
         - contactTracer: []
         - admin: []
-            
+
   '/point':
     put:
       summary: Updates an existing point of concern
@@ -817,7 +817,7 @@ paths:
             schema:
               $ref: '#/components/schemas/concernPointDb'
       responses:
-        '200': 
+        '200':
           description: 'OK'
           content:
             application/json:

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -74,7 +74,7 @@ describe('Case', () => {
     it('and return multiple case points', async () => {
       const results = await chai
         .request(server.app)
-        .get(`/case/points`)
+        .post(`/case/points`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send({ caseId: currentCase.caseId });
@@ -118,7 +118,7 @@ describe('Case', () => {
     it('and return points for all cases', async () => {
       const results = await chai
         .request(server.app)
-        .get(`/cases/points`)
+        .post(`/cases/points`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send({ caseIds: [caseOne.caseId, caseTwo.caseId, caseThree.caseId ]});
@@ -140,7 +140,7 @@ describe('Case', () => {
     it('and returns no points if no caseIds are passed', async () => {
       const results = await chai
         .request(server.app)
-        .get(`/cases/points`)
+        .post(`/cases/points`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send({ caseIds: []});
@@ -156,7 +156,7 @@ describe('Case', () => {
     it('and fails if caseIds are not passed', async () => {
       const results = await chai
         .request(server.app)
-        .get(`/cases/points`)
+        .post(`/cases/points`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send();
@@ -317,7 +317,7 @@ describe('Case', () => {
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send(requestParams);
-        
+
         result.error.should.be.false;
         result.should.have.status(200);
         result.body.should.be.a('object');

--- a/test/integration/organizations.test.js
+++ b/test/integration/organizations.test.js
@@ -177,7 +177,7 @@ describe('Organization ', () => {
 
       const results = await chai
         .request(server.app)
-        .delete(`/organization/case`)
+        .post(`/organization/case`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send(newParams);

--- a/test/integration/upload.test.js
+++ b/test/integration/upload.test.js
@@ -15,7 +15,7 @@ const uploadService = require('../../db/models/upload');
 
 chai.use(chaiHttp);
 
-describe('POST /case/points', () => {
+describe('POST /case/points/ingest', () => {
 
   let token, currentOrg, currentAccessCode;
 
@@ -54,7 +54,7 @@ describe('POST /case/points', () => {
   it('should fail for unauthorized clients', async () => {
     let result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .send();
     result.should.have.status(401);
   });
@@ -62,7 +62,7 @@ describe('POST /case/points', () => {
   it('should fail for malformed requests', async () => {
     let result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .set('Authorization', `Bearer ${token}`)
       .send({
         accessCode: "123456",
@@ -71,7 +71,7 @@ describe('POST /case/points', () => {
 
     result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .set('Authorization', `Bearer ${token}`)
       .send({
         caseId: 1,
@@ -82,7 +82,7 @@ describe('POST /case/points', () => {
   it('should fail for invalid access codes', async () => {
     let result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .set('Authorization', `Bearer ${token}`)
       .send({
         accessCode: "123456",
@@ -94,7 +94,7 @@ describe('POST /case/points', () => {
   it('should fail when consent is not granted', async () => {
     let result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .set('Authorization', `Bearer ${token}`)
       .send({
         accessCode: currentAccessCode.value,
@@ -110,13 +110,13 @@ describe('POST /case/points', () => {
 
     let result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .set('Authorization', `Bearer ${token}`)
       .send({
         accessCode: currentAccessCode.value,
         caseId: 1,
       });
-      
+
     result.should.have.status(202);
   });
 
@@ -133,13 +133,13 @@ describe('POST /case/points', () => {
 
     let result = await chai
       .request(server.app)
-      .post('/case/points')
+      .post('/case/points/ingest')
       .set('Authorization', `Bearer ${token}`)
       .send({
         accessCode: currentAccessCode.value,
         caseId: currentCase.caseId,
       });
-      
+
     result.should.have.status(200);
 
     chai.should().exist(result.body.concernPoints);


### PR DESCRIPTION
**What**

Body params on GET requests are incompatible with Axios fetch requests. We can't use query params or route params because of the following:

- Using query params was inconsistent with the other requests
- Using a route params or query params would leave logs in the server

So we should update these endpoints to be `POST` instead of `GET`