### PR TITLE
PLACES-344 move DELETE /{entity_name} to POST /{entity_name}/delete

### DIFF
--- a/app/api/case/router.js
+++ b/app/api/case/router.js
@@ -28,8 +28,8 @@ server.put(
   server.wrapAsync(async (req, res) => await controller.updateCasePoint(req, res), true),
 );
 
-server.delete(
-  '/case/point',
+server.post(
+  '/case/point/delete',
   server.wrapAsync(async (req, res) => await controller.deleteCasePoint(req, res), true),
 );
 
@@ -48,8 +48,8 @@ server.post(
   server.wrapAsync(async (req, res) => await controller.publishCases(req, res), true),
 );
 
-server.delete(
-  '/case',
+server.post(
+  '/case/delete',
   server.wrapAsync(async (req, res) => await controller.deleteCase(req, res), true),
 );
 

--- a/app/api/organization/controller.js
+++ b/app/api/organization/controller.js
@@ -135,27 +135,3 @@ exports.createOrganizationCase = async (req, res) => {
     res.status(500).json({ message: 'Internal Server Error' });
   }
 };
-
-/**
- * @method deleteOrganizationCase
- *
- * Delete case from Organization
- * Organization is pulled from the user.
- *
- */
-exports.deleteOrganizationCase = async (req, res) => {
-  const {
-    user: { organization_id },
-    body: { caseId }
-  } = req;
-
-  if (!organization_id) throw new Error('Organization ID is missing.');
-  if (!caseId) throw new Error('Case ID is missing.');
-
-  const results = await organizations.deleteCase(organization_id, caseId);
-  if (results) {
-    res.sendStatus(200);
-  } else {
-    res.status(500).json({ message: 'Internal Server Error' });
-  }
-};

--- a/app/api/organization/router.js
+++ b/app/api/organization/router.js
@@ -40,11 +40,3 @@ server.get(
     true,
   ),
 );
-
-server.post(
-  '/organization/case',
-  server.wrapAsync(
-    async (req, res) => await controller.deleteOrganizationCase(req, res),
-    true,
-  ),
-);

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -285,7 +285,7 @@ describe('Case', () => {
 
       const results = await chai
         .request(server.app)
-        .delete(`/case/point`)
+        .post(`/case/point/delete`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send(newParams);
@@ -637,7 +637,7 @@ describe('Case', () => {
 
       const results = await chai
         .request(server.app)
-        .delete(`/case`)
+        .post(`/case/delete`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send(newParams);

--- a/test/integration/organizations.test.js
+++ b/test/integration/organizations.test.js
@@ -16,7 +16,7 @@ const jwtSecret = require('../../config/jwtConfig');
 
 chai.use(chaiHttp);
 
-let currentOrg, caseToDelete, token;
+let currentOrg, token;
 
 describe('Organization ', () => {
 
@@ -55,7 +55,7 @@ describe('Organization ', () => {
 
     await mockData.mockCase(caseParams)
     await mockData.mockCase(caseParams)
-    caseToDelete = await mockData.mockCase(caseParams)
+    await mockData.mockCase(caseParams)
 
     token = jwt.sign(
       {
@@ -168,21 +168,6 @@ describe('Organization ', () => {
       firstChunk.state.should.be.a('string')
       firstChunk.should.have.property('updated_at');
       firstChunk.updated_at.should.be.a('string')
-    });
-
-    it('delete the record', async () => {
-      const newParams = {
-        caseId: caseToDelete.caseId,
-      };
-
-      const results = await chai
-        .request(server.app)
-        .post(`/organization/case`)
-        .set('Authorization', `Bearer ${token}`)
-        .set('content-type', 'application/json')
-        .send(newParams);
-
-      results.should.have.status(200);
     });
   });
 


### PR DESCRIPTION
While reviewing the existing spec I noticed that we have two endpoints that handle the deletion of cases (one in organizations controller and one in cases). I also noticed that some `DELETE` requests were not caught in the original PLACES-344 PR. I've update the `DELETE` requests to be `POST /{entity_name}/delete` since `DELETE` does not support request bodies.