### PR TITLE
[PLACES-379] Support configuration files

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,6 @@ LDAP_PORT=1389
 LDAP_PASS=safepaths
 LDAP_ORG="dc=covidsafepaths, dc=org"
 LDAP_BIND="cn=admin, dc=covidsafepaths, dc=org"
-LDAP_SEARCH="cn={{username}}, dc=covidsafepaths, dc=org"
-LDAP_FILTER="(objectClass=*)"
+LDAP_SEARCH="dc=covidsafepaths, dc=org"
+LDAP_FILTER="(&(objectClass=person)(cn={{username}}))"
 HASHING_TEST=1

--- a/.env.template
+++ b/.env.template
@@ -26,3 +26,4 @@ LDAP_ORG="dc=covidsafepaths, dc=org"
 LDAP_BIND="cn=admin, dc=covidsafepaths, dc=org"
 LDAP_SEARCH="cn={{username}}, dc=covidsafepaths, dc=org"
 LDAP_FILTER="(objectClass=*)"
+HASHING_TEST=1

--- a/.github/workflows/google-express.yml
+++ b/.github/workflows/google-express.yml
@@ -13,9 +13,7 @@ name: Deploy SafePlaces ExpressJS to GKE
 on:
   push:
     branches:
-      - dev
-      - PLACES-243
-      - jh-logging
+      - staging
 
 
 # Environment variables available to all jobs and steps in this workflow

--- a/.github/workflows/intergation-tests.yaml
+++ b/.github/workflows/intergation-tests.yaml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - dev-add-tests
+      - PLACES-338
     # paths:
     #   - 'expressjs/**/**'
 
@@ -36,13 +37,14 @@ env:
   DB_PASS_PUB: postgres
   JWT_SECRET: ${{ secrets.JWT_SECRET }}
   SEED_MAPS_API_KEY: ${{ secrets.SEED_MAPS_API_KEY }}
-  LDAP_HOST: ${{ secrets.LDAP_HOST }}
-  LDAP_PORT: ${{ secrets.LDAP_PORT }}
+  TESTS_ENV: ${{ secrets.TESTS_ENV }}
+  LDAP_HOST: localhost
+  LDAP_PORT: 6379
   LDAP_PASS: ${{ secrets.LDAP_PASS }}
-  LDAP_ORG: ${{ secrets.LDAP_ORG }}
-  LDAP_BIND: 'cn=admin,dc=covidsafepaths,dc=org'
-  LDAP_SEARCH: 'cn={{username}}, dc=covidsafepaths, dc=org'
-  LDAP_FILTER: '(objectClass=*)'
+  LDAP_ORG: 'dc=covidsafepaths, dc=org'
+  LDAP_BIND: 'cn=admin, dc=covidsafepaths, dc=org'
+  LDAP_SEARCH: 'dc=covidsafepaths, dc=org'
+  LDAP_FILTER: '(&(objectClass=person)(cn={{username}}))'
 
 jobs:
   run-integration-tests:
@@ -62,8 +64,8 @@ jobs:
           POSTGRESQL_POSTGRES_PASSWORD: postgres
 
         ports:
-            # Maps tcp port 5432 on service container to the host
-            - 5432:5432
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
 
     steps:
       - name: Checkout
@@ -72,10 +74,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '13.x'
-      - run: npm install
       - run: npm install -g knex
-      - run: npm run build --if-present
-      - run : npm test
+      - run: npm install
+      - run: npm run ldap:build
+      - run: |
+          npm run ldap:start &
+          echo $TESTS_ENV | base64 --decode --ignore-garbage > .env &&
+          source .env && npm test
         env:
           # The hostname used to communicate with the PostgreSQL service container
           POSTGRES_HOST: localhost

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .idea/
 .vscode/
 
+# Configuration, non-template files
+config.yml
 config.yaml
 
 # Logs
@@ -69,7 +71,6 @@ node_modules/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
 .env
 .envrc
 .git.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .idea/
 .vscode/
 
+config.yaml
+
 # Logs
 logs
 *.log

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,42 @@
+# Configuration
+
+The Safe Places server utilizes a configuration file in [YAML format
+version 1.2](https://yaml.org/spec/1.2/spec.html) for ease of use.
+This configuration file needs to be created for the server to function
+correctly.
+
+## Specifying the file path
+
+By default, the server looks for a configuration file named
+`config.yaml` at the root of the server directory.
+
+To specify another file path, use the `--config` flag when running
+the server.
+
+For example, to use a configuration file at the path
+`/root/spl-config.yaml`, you can run the server with
+
+```shell script
+npm start -- --config=/root/spl-config.yaml
+```
+
+**Note the two hyphens** `--` after `npm start`. This is required so
+that the `--config` flag is passed to the _server, not NPM_.
+
+## Configuration format
+
+_Last updated: 16 June 2020_
+
+See `config.template.yaml`, which is a sample configuration file that
+correctly follows the required schema. Feel free to copy that file
+and make modifications accordingly.
+
+The configuration file should match the following format,
+with no additional properties:
+
+```yaml
+allowedOrigins:
+# - your origins here (string value)
+  - https://example.com
+  - http://localhost:3000
+```

--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ LDAP_PORT=1389
 LDAP_PASS=safepaths
 LDAP_ORG="dc=covidsafepaths, dc=org"
 LDAP_BIND="cn=admin, dc=covidsafepaths, dc=org"
-LDAP_SEARCH="cn={{username}}, dc=covidsafepaths, dc=org"
-LDAP_FILTER="(objectClass=*)"
+LDAP_SEARCH="dc=covidsafepaths, dc=org"
+LDAP_FILTER="(&(objectClass=person)(cn={{username}}))"
 ```
 
 The Express server queries the LDAP server with each login request at `/login`.
 
 The search query will look like
-`cn={{username}}, dc=covidsafepaths, dc=org`
+`dc=covidsafepaths, dc=org`.
+
+The filter query will look like
+`(&(objectClass=person)(cn={{username}}))`.
 
 Note that `{{username}}` is **explicitly required.**
 `{{username}}` will be replaced by the username sent by the client's request.

--- a/app/api/case/controller.js
+++ b/app/api/case/controller.js
@@ -97,11 +97,11 @@ exports.ingestUploadedPoints = async (req, res) => {
     return;
   }
 
-  const points = await pointsService.createPointsFromUpload(caseId, uploadedPoints);
+  const concernPoints = await pointsService.createPointsFromUpload(caseId, uploadedPoints);
 
   await uploadService.deletePoints(accessCode);
 
-  res.status(200).json({ concernPoints: points });
+  res.status(200).json({ concernPoints });
 };
 
 /**
@@ -276,7 +276,7 @@ exports.publishCases = async (req, res) => {
 
   const organization = await organizationsService.fetchById(organization_id);
   if (organization) {
-    const publishResults = await casesService.publishCases(caseIds, organization.id);
+    const cases = await casesService.publishCases(caseIds, organization.id);
 
     const publicationParams = {
       organization_id: organization.id,
@@ -310,7 +310,6 @@ exports.publishCases = async (req, res) => {
           if (type ==='gcs') {
             const results = await writeToGCSBucket(pages);
             if (results) {
-              const cases = publishResults.map(itm => casesService._mapCase(itm));
               res.status(200).json({ cases });
               return;
             } else {
@@ -319,7 +318,6 @@ exports.publishCases = async (req, res) => {
           } else if (type === 'aws') {
             const results = await writeToS3Bucket(pages);
             if (results) {
-              const cases = publishResults.map(itm => casesService._mapCase(itm));
               res.status(200).json({ cases });
               return;
             } else {
@@ -332,7 +330,6 @@ exports.publishCases = async (req, res) => {
             } else if (type === 'local') {
               const results = await writePublishedFiles(pages, '/tmp/trails')
               if (results) {
-                let cases = publishResults.map(itm => casesService._mapCase(itm))
                 res.status(200).json({ cases });
                 return;
               }

--- a/app/api/case/controller.js
+++ b/app/api/case/controller.js
@@ -107,18 +107,20 @@ exports.ingestUploadedPoints = async (req, res) => {
 /**
  * @method deleteCasePoints
  *
- * Deletes all points of concern for the provided case.
+ * Deletes the given points of concern.
  *
  */
 exports.deleteCasePoints = async (req, res) => {
-  const { caseId } = req.body;
+  const { pointIds } = req.body;
 
-  if (caseId ==  null) {
+  if (pointIds ==  null || !_.isArray(pointIds)) {
     res.status(400).send();
     return;
   }
 
-  await pointsService.deleteWhere({ case_id: caseId });
+  if (pointIds.length > 0) {
+    await pointsService.deleteIds(pointIds);
+  }
 
   res.status(200).send();
 };

--- a/app/api/organization/controller.js
+++ b/app/api/organization/controller.js
@@ -92,18 +92,9 @@ exports.fetchOrganizationCases = async (req, res) => {
 
   await organizations.cleanOutExpiredCases(organization_id)
 
-  let cases = await organizations.getCases(organization_id);
-  if (cases) {
-    cases = cases.map(c => {
-      // delete c.organization_id
-      delete c.publication_id
-      delete c.created_at
-      return c
-    })
-    res.status(200).json({ cases });
-  } else {
-    throw new Error(`Could not fetch organization cases by users org id ${organization_id}.`);
-  }
+  const cases = await organizations.getCases(organization_id);
+
+  res.status(200).json({ cases });
 };
 
 /**

--- a/app/lib/geoHash.js
+++ b/app/lib/geoHash.js
@@ -26,7 +26,7 @@ We use a scrypt hash with the following parameters:
  * @return {String}
  */
 
-const encrypt = async (location, salt = 'salt', debug = false) => {
+const encrypt = async (location, salt = 'salt') => {
   const roundDownTo = roundTo => x => Math.floor(x / roundTo) * roundTo;
   const roundDownTo5Minutes = roundDownTo(1000*60*5);
   const roundedTime = roundDownTo5Minutes(new Date(location.time));
@@ -40,10 +40,7 @@ const encrypt = async (location, salt = 'salt', debug = false) => {
   const derivedKey = await Promise.fromCallback(cb => crypto.scrypt(secret, salt, 8, options, cb));
   if (derivedKey) {
     const encodedString = derivedKey.toString('hex'); 
-    if (debug) {
-      return { hash, secret, encodedString };
-    }
-    return { encodedString };
+    return { hash, secret, encodedString };
   }
 };
 

--- a/app/lib/pocTransform.js
+++ b/app/lib/pocTransform.js
@@ -125,7 +125,7 @@ const durationPointToDiscreetPoints = durationPoint => {
       longitude: durationPoint.longitude,
       time: durationPoint.time + i * 5 * MINUTE,
       hash: durationPoint.hash,
-      publish_date: durationPoint.publish_date
+      publishDate: durationPoint.publishDate
     };
   }
   return discreetPoints;

--- a/app/lib/publicationFiles.js
+++ b/app/lib/publicationFiles.js
@@ -22,7 +22,7 @@ class PublicationFiles {
    * @return {Object}
    */
   async build(organization, record, trails) {
-    if (!organization.apiEndpointUrl) throw new Error('Your API endpoint is invalid.') 
+    if (!organization.apiEndpointUrl) throw new Error('Your API endpoint is invalid.')
 
     let endpoint = organization.apiEndpointUrl
     if (endpoint.substr((endpoint.length - 1), 1) !== '/') {
@@ -46,7 +46,7 @@ class PublicationFiles {
   }
 
   /**
-   * 
+   *
    * Build Publication File Content and return zip file Buffer.
    *
    * @method build
@@ -55,12 +55,12 @@ class PublicationFiles {
    * @param {Array[Trails]} trails
    * @return {<Promise>ZipFile}
    */
-  
+
   async buildAndZip(organization, record, trails) {
     const pages = await this.build(organization, record, trails)
     if (pages) {
       const zip = new AdmZip();
-  
+
       let filename;
       zip.addFile("instructions.txt", "Place all files in the `trails` folder onto your web server.");
       zip.addFile('trails/', Buffer.from(''));
@@ -78,7 +78,7 @@ class PublicationFiles {
   // private
 
   /**
-   * 
+   *
    * Fetch Header
    *
    * @method _getHeader
@@ -86,7 +86,7 @@ class PublicationFiles {
    * @param {Object} record
    * @return {Object}
    */
-  
+
   _getHeader(organization, record) {
     return {
       version: "1.0",
@@ -102,14 +102,14 @@ class PublicationFiles {
   }
 
   /**
-   * 
+   *
    * Transform from duration to discreet and build hashes.
    *
    * @method _transformAndHash
    * @param {Array[Trails]} trails
    * @return {Array[HashedTrails]}
    */
-  
+
   async _transformAndHash(trails) {
     trails = transform.durationToDiscreet(trails)
 
@@ -165,7 +165,7 @@ class PublicationFiles {
 
   /**
    * Build pages based on chunking time.
-   * Remember, the time we are looking at is the Published time for the case, not the time 
+   * Remember, the time we are looking at is the Published time for the case, not the time
    * of the point.
    *
    * @private
@@ -201,7 +201,7 @@ class PublicationFiles {
     }
 
     // Get Publication dates, and sort them.
-    let publicationDates = [...new Set(trails.map(trail => new Date(trail.publish_date).getTime()))];
+    let publicationDates = [...new Set(trails.map(trail => new Date(trail.publishDate).getTime()))];
     publicationDates = publicationDates.sort((a,b) => (a.time > b.time) ? 1 : ((b.time > a.time) ? -1 : 0)).reverse(); // Assure they are sorted properly.
 
     // Goto 1 second before Midnight of the most recent publication
@@ -227,12 +227,12 @@ class PublicationFiles {
       if (lastPublicationTimestamp >= endTimestamp) break;
     }
 
-    // Find Trails. We are checking the publish time of the publication that is associated with the 
+    // Find Trails. We are checking the publish time of the publication that is associated with the
     // case and therefore the trail.
     // Remove any empty groups that don't have any trails associated with them.
     groups = groups.map(group => {
       group.trails = trails.filter(trail => {
-        const publishDateTs = new Date(trail.publish_date).getTime();
+        const publishDateTs = new Date(trail.publishDate).getTime();
         if (publishDateTs <= group.startTimestamp && publishDateTs >= group.endTimestamp) {
           return true;
         }

--- a/app/lib/publicationFiles.js
+++ b/app/lib/publicationFiles.js
@@ -38,6 +38,7 @@ class PublicationFiles {
     const files = trailsChunked.map(chunk => {
       const newHeader = _.clone(header)
       newHeader.concern_point_hashes = this._getPointHashes(chunk)
+      if (process.env.HASHING_TEST) newHeader.points_for_test = chunk.trails
       newHeader.page_name = this._apiEndpointPage.replace('[PAGE]', `${chunk.startTimestamp}_${chunk.endTimestamp}`)
       return newHeader;
     })
@@ -119,7 +120,8 @@ class PublicationFiles {
     for(trail of trails) {
       hash = await geoHash.encrypt(trail)
       if (hash) {
-        trail.hash = hash.encodedString
+        trail.hash = hash.encodedString;
+        trail.secret = hash.secret;
         trailRecords.push(trail);
       }
     }

--- a/base/env/test/deployment.yml
+++ b/base/env/test/deployment.yml
@@ -23,7 +23,7 @@ spec:
             value: "3000"
           envFrom:
             - secretRef:
-                name: expressapp
+                name: hrmes-spl-be
           ports:
             - name: express
               containerPort: 3000

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Safe Places Configuration",
+  "description": "The configuration file consumed by the Safe Places server",
+  "type": "object",
+  "properties": {
+    "allowedOrigins": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -1,0 +1,8 @@
+---
+allowedOrigins:
+  - http://localhost:3000
+  - http://localhost:3001
+  - http://localhost:5000
+  - https://zeus.safeplaces.extremesolution.com
+  - https://hermes.safeplaces.extremesolution.com
+  - https://safeplaces.extremesolution.com

--- a/db/models/organizations.js
+++ b/db/models/organizations.js
@@ -141,7 +141,7 @@ class Service extends BaseService {
   async getCases(id) {
     const results = await casesService.fetchAll(id)
     if (results) {
-      return results
+      return results;
     }
     throw new Error('Internal server errror.')
   }

--- a/db/models/points.js
+++ b/db/models/points.js
@@ -99,6 +99,11 @@ class Service extends BaseService {
     );
   }
 
+  deleteIds(ids) {
+    if (!ids) throw new Error('Invalid point ids');
+    return this.table.whereIn('id', ids).del();
+  }
+
   // private
 
   /**
@@ -140,15 +145,16 @@ class Service extends BaseService {
       let trail = {};
       const b = new Buffer.from(point.coordinates, 'hex');
       const c = wkx.Geometry.parse(b);
-      trail.publish_date = point.publish_date || null
-      trail.caseId = point.caseId || point.case_id || null
-      trail.pointId = point.pointId || point.id
+      trail.id = point.id;
+      trail.publish_date = point.publish_date || null;
+      trail.caseId = point.caseId || point.case_id || null;
+      trail.pointId = point.pointId || point.id;
       trail.longitude = c.x;
       trail.latitude = c.y;
       trail.duration = point.duration;
       if (includeHash) trail.hash = point.hash;
       trail.time = (point.time.getTime() / 1000);
-      if (returnDateTime) trail.time = point.time
+      if (returnDateTime) trail.time = point.time;
       redactedTrail.push(trail);
     });
 

--- a/db/models/points.js
+++ b/db/models/points.js
@@ -146,9 +146,9 @@ class Service extends BaseService {
       const b = new Buffer.from(point.coordinates, 'hex');
       const c = wkx.Geometry.parse(b);
       trail.id = point.id;
-      trail.publish_date = point.publish_date || null;
+      trail.publishDate = point.publishDate || point.publish_date || null;
       trail.caseId = point.caseId || point.case_id || null;
-      trail.pointId = point.pointId || point.id;
+      trail.pointId = point.pointId || point.id || null;
       trail.longitude = c.x;
       trail.latitude = c.y;
       trail.duration = point.duration;

--- a/dbsetup.sh
+++ b/dbsetup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# knex --knexfile /app/knexfile.js migrate:latest --env test
-knex --knexfile /app/knexfile.js migrate:latest --env development
+knex --knexfile /app/knexfile.js migrate:latest --env $NODE_ENV
 
-# knex --knexfile /app/knexfile.js seed:run --env test
-knex --knexfile /app/knexfile.js seed:run --env development
+if [ $NODE_ENV = "development" ]; then
+  knex --knexfile /app/knexfile.js seed:run --env $NODE_ENV
+fi
 
 exec "$@"

--- a/knexfile-public.js
+++ b/knexfile-public.js
@@ -22,6 +22,15 @@ module.exports = {
       database: process.env.DB_NAME_PUB,
     },
   },
+  staging: {
+    client: 'pg',
+    connection: {
+      host: process.env.DB_HOST_PUB,
+      user: process.env.DB_USER_PUB,
+      password: process.env.DB_PASS_PUB,
+      database: process.env.DB_NAME_PUB,
+    },
+  },
   production: {
     client: 'pg',
     connection: {

--- a/knexfile.js
+++ b/knexfile.js
@@ -34,6 +34,21 @@ module.exports = {
       directory: __dirname + '/db/seeds/development',
     },
   },
+  staging: {
+    client: 'pg',
+    connection: {
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASS,
+      database: process.env.DB_NAME,
+    },
+    migrations: {
+      directory: __dirname + '/db/migrations',
+    },
+    seeds: {
+      directory: __dirname + '/db/seeds/development',
+    },
+  },
   production: {
     client: 'pg',
     connection: {

--- a/ldapjs/ldapServer.js
+++ b/ldapjs/ldapServer.js
@@ -41,7 +41,7 @@ function loadPasswd(req, res, next) {
       if (!record || !record.length) continue;
 
       req.users[record[0]] = {
-        dn: `cn=${record[0]}, ${process.env.LDAP_ORG}`,
+        dn: process.env.LDAP_ORG,
         attributes: {
           cn: record[0],
           userPassword: record[1],
@@ -56,7 +56,7 @@ function loadPasswd(req, res, next) {
 
 const pre = [authorize, loadPasswd];
 
-server.search(process.env.LDAP_ORG, pre, function (req, res, next) {
+server.search(process.env.LDAP_SEARCH, pre, function (req, res, next) {
   console.log('[LDAP] search');
   Object.keys(req.users).forEach(function (k) {
     if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -4109,6 +4109,11 @@
         "@types/geojson": "^7946.0.7"
       }
     },
+    "ldap-escape": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/ldap-escape/-/ldap-escape-2.0.4.tgz",
+      "integrity": "sha512-j29sWZOjN/PQ0/Q9o5ifDHM8Py8tpAh4Opr3Q27IsyFH1Fg9qFhg6aig76DBrmJlvUYfQsoK1z3wp+n9VBSLMQ=="
+    },
     "ldap-filter": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.2.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,8 +497,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/cookiejar": {
       "version": "2.1.1",
@@ -612,7 +611,6 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -923,20 +921,57 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "3.1.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "boom": {
@@ -1035,9 +1070,9 @@
       }
     },
     "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1086,8 +1121,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "chai": {
       "version": "4.2.0",
@@ -1296,7 +1330,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1306,14 +1339,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -1323,7 +1354,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1331,26 +1361,22 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -1361,7 +1387,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -1370,7 +1395,6 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -1562,11 +1586,18 @@
         "vary": "^1"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
       "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1577,7 +1608,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -1629,8 +1659,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2347,10 +2376,43 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+          "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "~1.6.3",
+            "iconv-lite": "0.4.23",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.2",
+            "raw-body": "2.3.3",
+            "type-is": "~1.6.16"
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+        },
         "cookie": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "raw-body": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+          "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
+            "unpipe": "1.0.0"
+          }
         }
       }
     },
@@ -2502,16 +2564,14 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2877,8 +2937,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -3945,8 +4004,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5359,8 +5417,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -5682,8 +5739,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -5762,14 +5818,46 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "rc": {
@@ -5856,14 +5944,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.16.1",
@@ -6079,7 +6165,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -6087,8 +6172,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shelljs": {
       "version": "0.3.0",
@@ -6724,6 +6808,11 @@
       "integrity": "sha1-bcBtVFvJm9OgfWydXKxNfFj4qwc=",
       "dev": true
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "ts-jest": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
@@ -6924,7 +7013,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -7106,8 +7194,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.3",
@@ -7243,19 +7330,22 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+    },
     "yargs": {
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
       "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
-      "dev": true,
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -7273,20 +7363,17 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -7295,14 +7382,12 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -7311,7 +7396,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -7319,14 +7403,12 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -7337,7 +7419,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -7346,7 +7427,6 @@
           "version": "18.1.3",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
     "pretest": "knex migrate:latest && knex seed:run --env test",
-    "test": "nyc --reporter=html --reporter=text mocha test/**/*.* --exit",
+    "test": "cross-env BYPASS_CORS=true nyc --reporter=html --reporter=text mocha test/**/*.* --exit",
     "posttest": "knex seed:run --env development",
     "test:int": "mocha test/integration/*.* --exit",
     "test:unit": "mocha test/unit/*.* --exit",
@@ -28,13 +28,16 @@
   "dependencies": {
     "@google-cloud/storage": "^5.0.1",
     "adm-zip": "^0.4.14",
+    "ajv": "^6.12.2",
     "atob": "^2.1.2",
     "aws-sdk": "^2.692.0",
     "bcrypt": "^4.0.1",
     "bluebird": "^3.7.2",
+    "body-parser": "^1.19.0",
     "boom": "^7.3.0",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
+    "cross-env": "^7.0.2",
     "crypto": "^1.0.1",
     "debug": "~2.6.9",
     "express": "~4.16.1",
@@ -58,7 +61,9 @@
     "sinon": "^9.0.2",
     "winston": "2.4.4",
     "winston-papertrail": "^1.0.5",
-    "wkx": "^0.5.0"
+    "wkx": "^0.5.0",
+    "yaml": "^1.10.0",
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jszip": "^3.4.0",
     "knex": "^0.20.15",
     "knex-postgis": "^0.12.0",
+    "ldap-escape": "^2.0.4",
     "ldapjs": "^1.0.2",
     "moment": "~2.19.3",
     "morgan": "~1.9.1",

--- a/src/server/express.js
+++ b/src/server/express.js
@@ -28,12 +28,13 @@ class Server {
 
     this._app.use(cors({
       origin: (origin, callback) => {
-        if (BYPASS_CORS === 'true') return callback(null, true);
+        return callback(null, true);
+        /*if (BYPASS_CORS === 'true') return callback(null, true);
         if (config.allowedOrigins.indexOf(origin) !== -1) {
           return callback(null, true);
         }
 
-        return callback(new Error('Not allowed by CORS'));
+        return callback(new Error('Not allowed by CORS'));*/
       }
     }));
     this._app.use(cookieParser());

--- a/src/server/express.js
+++ b/src/server/express.js
@@ -1,3 +1,5 @@
+const BYPASS_CORS = process.env.BYPASS_CORS || 'false';
+
 const express = require('express');
 const http = require('http');
 const Promise = require('bluebird');
@@ -12,6 +14,7 @@ const responseTimeHandler = require('./responseTimeHandler');
 const expressSession = require('express-session');
 const cookieParser = require('cookie-parser');
 const passport = require('./passport');
+const config = require('../../tools/config').get();
 
 class Server {
   constructor() {
@@ -23,7 +26,16 @@ class Server {
     })
     const bodyParseEncoded = bodyParser.urlencoded({ extended: false })
 
-    this._app.use(cors());
+    this._app.use(cors({
+      origin: (origin, callback) => {
+        if (BYPASS_CORS === 'true') return callback(null, true);
+        if (config.allowedOrigins.indexOf(origin) !== -1) {
+          return callback(null, true);
+        }
+
+        return callback(new Error('Not allowed by CORS'));
+      }
+    }));
     this._app.use(cookieParser());
     this._app.use(expressLogger()); // Log Request
     this._app.use(bodyParseJson);

--- a/src/server/passport.js
+++ b/src/server/passport.js
@@ -4,6 +4,7 @@ const ExtractJWT = require('passport-jwt').ExtractJwt;
 const jwtSecret = require('../../config/jwtConfig');
 const users = require('../../db/models/users');
 const ldap = require('ldapjs');
+const ldapEscape = require('ldap-escape');
 const CustomStrategy = require('passport-custom').Strategy;
 
 const ldapServerUrl = `ldap://${process.env.LDAP_HOST}:${process.env.LDAP_PORT}`;
@@ -35,13 +36,13 @@ const jwtStrategy = new JWTstrategy(opts, async (jwt_payload, done) => {
 
 passport.use('jwt', jwtStrategy);
 
-console.log('[LDAP] CreateClient')
+console.log('[LDAP] CreateClient');
 const ldapClient = ldap.createClient({
   url: ldapServerUrl,
 });
 
 ldapClient.on('error', err => {
-  console.log('[LDAP] on Error', err)
+  console.log('[LDAP] on Error', err);
   if (err.message.startsWith('connect ECONNREFUSED')) {
     throw new Error(`LDAP server not found at ${ldapServerUrl}. Please start a server to enable authentication. Please see README.md for more information.`);
   } else {
@@ -50,7 +51,7 @@ ldapClient.on('error', err => {
 });
 
 ldapClient.bind(process.env.LDAP_BIND, process.env.LDAP_PASS, err => {
-  console.log('[LDAP] bind outside')
+  console.log('[LDAP] bind outside');
   if (err) console.log(err);
 });
 
@@ -59,44 +60,58 @@ ldapClient.bind(process.env.LDAP_BIND, process.env.LDAP_PASS, err => {
  */
 
 if (
-  process.env.LDAP_SEARCH.indexOf('{{username}}') === -1
+  process.env.LDAP_FILTER.indexOf('{{username}}') === -1
 ) {
-  console.log('[LDAP] error thrown')
+  console.log('[LDAP] error thrown');
   throw new Error(
     'LDAP_FILTER environment variable must contain the keyword {{username}}. ' +
-    'These keywords will be replaced by the request details appropriately.'
-  )
+    'These keywords will be replaced by the request details appropriately.',
+  );
 }
 
 passport.use('ldap', new CustomStrategy(
   function(req, done) {
     /*
      * Filter will look like
-     * (&(cn={{username}})(password={{password}}))
+     * (&(cn={{username}})(objectClass=person))
      * {{username}} will be replaced by the sent username
-     * {{password}} will be replaced by the sent password
      */
-    
-    console.log('[LDAP] custom strategy')
 
-    let query =
-      process.env.LDAP_SEARCH
-      .replace(/{{username}}/g, req.body.username);
+    console.log('[LDAP] custom strategy');
+
+    const filter =
+      process.env.LDAP_FILTER
+        .replace(/{{username}}/g, ldapEscape.filter`${req.body.username}`);
+
+    const query = process.env.LDAP_SEARCH;
 
     ldapClient.search(query, {
-      filter: process.env.LDAP_FILTER,
+      filter,
       scope: 'base',
-      // attributes: ['dn', 'sn', 'cn']
     }, (err, res) => {
+      console.log('[LDAP] search callback');
+
+      if (err) console.error(err);
+
       res.on('searchEntry', function(entry) {
+        if (process.env.NODE_ENV === 'development') {
+          console.log('[LDAP] search entry');
+          console.debug(entry);
+        }
+
         // Compare the retrieved password and the sent password.
         if (entry.object.userPassword !== req.body.password) {
           return done(null, {});
         }
+
         return done(err, entry.object);
       });
+
       res.on('error', function(err) {
-        if (process.env.NODE_ENV === 'development') console.log(err.message);
+        if (process.env.NODE_ENV === 'development') {
+          console.log('[LDAP] search error');
+          console.error(err.message);
+        }
         return done(null, {});
       });
     });

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -143,7 +143,7 @@ describe('Case', () => {
         .post(`/cases/points`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
-        .send({ caseIds: []});
+        .send({ caseIds: [] });
 
       results.error.should.be.false;
       results.should.have.status(200);
@@ -383,6 +383,8 @@ describe('Case', () => {
         result.body.should.have.property('case');
         result.body.case.should.be.a('object');
         result.body.case.should.have.property('caseId');
+        result.body.case.should.have.property('externalId');
+        result.body.case.should.have.property('contactTracerId');
         result.body.case.should.have.property('state');
         result.body.case.should.have.property('updatedAt');
         result.body.case.should.have.property('expiresAt');
@@ -470,6 +472,7 @@ describe('Case', () => {
 
       results.body.cases.forEach(c => {
         c.should.have.property('caseId');
+        c.should.have.property('externalId');
         c.should.have.property('contactTracerId');
         c.state.should.be.equal('published');
         c.should.have.property('state');
@@ -499,7 +502,7 @@ describe('Case', () => {
 
       results.body.files.should.be.a('array');
 
-      const firstChunk = results.body.files.shift()
+      const firstChunk = results.body.files.shift();
       firstChunk.should.be.a('object');
 
       firstChunk.should.have.property('name');

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -493,7 +493,6 @@ describe('Case', () => {
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send(newParams);
-
       let pageEndpoint = `${currentOrg.apiEndpointUrl}[PAGE].json`
 
       results.error.should.be.false;
@@ -511,6 +510,9 @@ describe('Case', () => {
       firstChunk.should.have.property('concern_point_hashes');
       firstChunk.should.have.property('info_website_url');
       firstChunk.should.have.property('publish_date_utc');
+      if (process.env.HASHING_TEST) {
+        firstChunk.should.have.property('points_for_test');
+      }
       firstChunk.name.should.equal(currentOrg.name);
       firstChunk.info_website_url.should.equal(currentOrg.infoWebsiteUrl);
 

--- a/test/integration/login.test.js
+++ b/test/integration/login.test.js
@@ -26,7 +26,6 @@ function parseJwt(token) {
 }
 
 describe('POST /login', function() {
-
   it('should login on user creds and return map api key', function(done) {
     chai
       .request(server.app)

--- a/test/integration/organizations.test.js
+++ b/test/integration/organizations.test.js
@@ -94,7 +94,7 @@ describe('Organization ', () => {
         .get(`/organization/configuration`)
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json');
-        
+
       results.should.have.status(200);
       results.body.id.should.equal(currentOrg.id);
       results.body.externalId.should.equal(currentOrg.externalId);
@@ -166,12 +166,12 @@ describe('Organization ', () => {
       results.body.cases.length.should.equal(3);
 
       const firstChunk = results.body.cases.shift()
-      firstChunk.should.have.property('id');
-      firstChunk.id.should.be.a('number')
+      firstChunk.should.have.property('caseId');
+      firstChunk.should.have.property('externalId');
+      firstChunk.should.have.property('contactTracerId');
       firstChunk.should.have.property('state');
-      firstChunk.state.should.be.a('string')
-      firstChunk.should.have.property('updated_at');
-      firstChunk.updated_at.should.be.a('string')
+      firstChunk.should.have.property('updatedAt');
+      firstChunk.should.have.property('expiresAt');
     });
   });
 
@@ -189,6 +189,7 @@ describe('Organization ', () => {
       results.should.have.status(200);
       results.body.should.be.a('object');
       results.body.should.have.property('caseId');
+      results.body.should.have.property('externalId');
       results.body.should.have.property('contactTracerId');
       results.body.should.have.property('state');
       results.body.should.have.property('updatedAt');

--- a/tests/tests/FASTAPI.postman_environment.json
+++ b/tests/tests/FASTAPI.postman_environment.json
@@ -4,7 +4,7 @@
   "values": [
     {
       "key": "baseUrl",
-      "value": "https://hermes.api.express.safeplaces.extremesolution.com",
+      "value": "https://zeus.safeplaces.extremesolution.com",
       "enabled": true
     },
     {

--- a/tools/config/index.js
+++ b/tools/config/index.js
@@ -1,0 +1,101 @@
+/**
+ * Configuration loader
+ *
+ * The configuration loader looks for a configuration file in one of two places:
+ * 1. The root of the project, at `/config.yaml`.
+ * 2. The path specified via command-line arguments, using the flag `--config`.
+ *
+ * It reads the YAML file into memory, throwing helpful errors if any problems
+ * occur, and then validates its schema based on a pre-defined schema.
+ *
+ * The schema validation helper is `schema.js` and uses the `config.schema.json`
+ * file as the schema. The schema uses the standardized JSON schema draft-07.
+ *
+ * The end result is the configuration in JSON format.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+const { argv } = require('yargs');
+const { validate } = require('./schema');
+
+// Try to load the configuration file.
+const config = parse(getConfigPath());
+
+/**
+ * Determines the path to the configuration file.
+ *
+ * @returns the path to the configuration file.
+ */
+function getConfigPath() {
+  // THe configuration path can be modified using the `--config` flag.
+  // Default to the `config.yaml` file at the root of the application.
+  return argv.config || 'config.yaml';
+}
+
+/**
+ * Parses the configuration file at the specified file path.
+ *
+ * @param filePath The path to the configuration file.
+ * @returns the parsed configuration data in JSON format.
+ */
+function parse(filePath) {
+  // Resolve the location of the configuration file based on the current
+  // working directory and the specified file path.
+  const absPath = path.resolve(process.cwd(), filePath);
+
+  // Try to read the file at the location.
+  let data;
+  try {
+    data = fs.readFileSync(absPath).toString('utf-8');
+  } catch (err) {
+    // Catch a file not found error and throw a meaningful error message.
+    if (err.message.startsWith('ENOENT: no such file or directory')) {
+      throw new Error(
+        `Unable to find configuration file at ${absPath}. ` +
+        `Try duplicating the 'config.template.yaml' file.`, // TODO: Create template
+      );
+    }
+    throw err;
+  }
+
+  // Throw an error if there is nothing in the configuration file.
+  if (data === '') {
+    throw new Error('The YAML configuration file is empty');
+  }
+
+  // Try to parse the configuration file, and throw an error
+  // if the file is invalid.
+  let parsed;
+  try {
+    parsed = yaml.parse(data);
+  } catch (err) {
+    throw new Error(
+      'An error occurred while trying to parse the YAML configuration file: ' +
+      err.message,
+    );
+  }
+
+  // Validate the parsed YAML using the pre-defined schema.
+  const [valid, errors] = validate(parsed);
+  if (!valid) {
+    console.error('The configuration schema is invalid:');
+    console.error(errors);
+    throw new Error('Invalid configuration');
+  }
+
+  // All tests has passed, return the configuration JSON.
+  return parsed;
+}
+
+/**
+ * Gets the configuration data.
+ *
+ * @returns the configuration data in JSON format.
+ */
+function get() {
+  return config;
+}
+
+module.exports = { get };

--- a/tools/config/schema.js
+++ b/tools/config/schema.js
@@ -1,0 +1,23 @@
+const Ajv = require('ajv');
+const fs = require('fs');
+const path = require('path');
+const ajv = new Ajv();
+
+// Parse the JSON schema.
+const schema = JSON.parse(fs
+  .readFileSync(path.resolve(__dirname, '../../config.schema.json'))
+  .toString('utf-8'));
+// Compile the JSON schema.
+const check = ajv.compile(schema);
+
+/**
+ * Validates the json based on the pre-defined schema.
+ * @param json The JSON to validate.
+ * @returns a boolean of whether the JSON is valid.
+ */
+function validate(json) {
+  const valid = check(json);
+  return [valid, check.errors];
+}
+
+module.exports = { validate };


### PR DESCRIPTION
Thanks for taking a look at these changes. They primarily fall under the category of "quality-of-life improvements".

[Link to Jira task](https://pathcheck.atlassian.net/browse/PLACES-379?atlOrigin=eyJpIjoiMzgwYzczNTY4MTVlNGYwMmJjNTQ5NTQ3NmNhMTc1NmQiLCJwIjoiaiJ9).

## Motivation
The Safe Places backend uses about 30 environment variables. We can shift some of variables which require frequent configuration and/or do not require sensitivity to a user-friendly configuration file.

This also allows more flexible configuration formats, such as using arrays, which is difficult to support using en environment variable.

## Some notable changes
- New template configuration file
- New configuration schema
- New utility for reading the configuration and loading it into memory (throws helpful errors if something is wrong)
  - This is located at `/tools/config` and is well-documented.
- Functionality for CORS allowed origins for later use (currently commented out)

I believe these changes are fully backwards-compatible - no old environment variables were moved to the configuration file. Only a new, currently unused `allowedOrigins` setting is added.

Please read the [configuration guide](https://github.com/Path-Check/safeplaces-backend/blob/aab10be3e853154c9be0535ef85cd414ea247477/CONFIGURATION.md) for more detailed information about this enhancement.

## Some design decisions
- The configuration is not passed around as a constant. Instead, it is retrieved on-the-fly by importing `/tools/config` and running the `config.get()` function. The hope was to prevent a messy tree of passing down a configuration object.
- The YAML format was chosen instead of JSON because it seems more user-friendly and more human-readable
- By default, the utility looks for a configuration file named `config.yaml` at the server root. Another path can be specified by passing the `--config=/path/to/config/file.yaml` flag to the server.

If there exists any possible improvements over the above, let's change it!

## Tests
<img width="518" alt="image" src="https://user-images.githubusercontent.com/48393820/84787929-89460000-afbc-11ea-9d7f-8d7531d6ee02.png">
