### PR TITLE
Adding in test data for development

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,3 +26,4 @@ LDAP_ORG="dc=covidsafepaths, dc=org"
 LDAP_BIND="cn=admin, dc=covidsafepaths, dc=org"
 LDAP_SEARCH="cn={{username}}, dc=covidsafepaths, dc=org"
 LDAP_FILTER="(objectClass=*)"
+HASHING_TEST=1

--- a/app/lib/geoHash.js
+++ b/app/lib/geoHash.js
@@ -26,7 +26,7 @@ We use a scrypt hash with the following parameters:
  * @return {String}
  */
 
-const encrypt = async (location, salt = 'salt', debug = false) => {
+const encrypt = async (location, salt = 'salt') => {
   const roundDownTo = roundTo => x => Math.floor(x / roundTo) * roundTo;
   const roundDownTo5Minutes = roundDownTo(1000*60*5);
   const roundedTime = roundDownTo5Minutes(new Date(location.time));
@@ -40,10 +40,7 @@ const encrypt = async (location, salt = 'salt', debug = false) => {
   const derivedKey = await Promise.fromCallback(cb => crypto.scrypt(secret, salt, 8, options, cb));
   if (derivedKey) {
     const encodedString = derivedKey.toString('hex'); 
-    if (debug) {
-      return { hash, secret, encodedString };
-    }
-    return { encodedString };
+    return { hash, secret, encodedString };
   }
 };
 

--- a/app/lib/publicationFiles.js
+++ b/app/lib/publicationFiles.js
@@ -38,7 +38,7 @@ class PublicationFiles {
     const files = trailsChunked.map(chunk => {
       const newHeader = _.clone(header)
       newHeader.concern_point_hashes = this._getPointHashes(chunk)
-      if (['production','staging'].indexOf(process.env.NODE_ENV) < 0) newHeader.points_for_test = chunk
+      if (process.env.HASHING_TEST) newHeader.points_for_test = chunk.trails
       newHeader.page_name = this._apiEndpointPage.replace('[PAGE]', `${chunk.startTimestamp}_${chunk.endTimestamp}`)
       return newHeader;
     })

--- a/app/lib/publicationFiles.js
+++ b/app/lib/publicationFiles.js
@@ -38,6 +38,7 @@ class PublicationFiles {
     const files = trailsChunked.map(chunk => {
       const newHeader = _.clone(header)
       newHeader.concern_point_hashes = this._getPointHashes(chunk)
+      if (['production','staging'].indexOf(process.env.NODE_ENV) < 0) newHeader.points_for_test = chunk
       newHeader.page_name = this._apiEndpointPage.replace('[PAGE]', `${chunk.startTimestamp}_${chunk.endTimestamp}`)
       return newHeader;
     })
@@ -119,7 +120,8 @@ class PublicationFiles {
     for(trail of trails) {
       hash = await geoHash.encrypt(trail)
       if (hash) {
-        trail.hash = hash.encodedString
+        trail.hash = hash.encodedString;
+        trail.secret = hash.secret;
         trailRecords.push(trail);
       }
     }

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -507,7 +507,7 @@ describe('Case', () => {
       firstChunk.should.have.property('concern_point_hashes');
       firstChunk.should.have.property('info_website_url');
       firstChunk.should.have.property('publish_date_utc');
-      if (['production','staging'].indexOf(process.env.NODE_ENV) < 0) {
+      if (process.env.HASHING_TEST) {
         firstChunk.should.have.property('points_for_test');
       }
       firstChunk.name.should.equal(currentOrg.name);

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -490,7 +490,6 @@ describe('Case', () => {
         .set('Authorization', `Bearer ${token}`)
         .set('content-type', 'application/json')
         .send(newParams);
-
       let pageEndpoint = `${currentOrg.apiEndpointUrl}[PAGE].json`
 
       results.error.should.be.false;
@@ -508,6 +507,9 @@ describe('Case', () => {
       firstChunk.should.have.property('concern_point_hashes');
       firstChunk.should.have.property('info_website_url');
       firstChunk.should.have.property('publish_date_utc');
+      if (['production','staging'].indexOf(process.env.NODE_ENV) < 0) {
+        firstChunk.should.have.property('points_for_test');
+      }
       firstChunk.name.should.equal(currentOrg.name);
       firstChunk.info_website_url.should.equal(currentOrg.infoWebsiteUrl);
 


### PR DESCRIPTION
Hash data is difficult to confirm and is looking a bit peculiar.  This adds in a new variable to the files that are generated that has all of the data that is used to create the hashes so we can verify.

This information is only available when`process.env.NODE_ENV === 'development'`

@AdamLeonSmith this should unblock you.