### PR TITLE
Represent publish_date in cursor/trails json as milliseconds instead of seconds

### DIFF
--- a/app/api/case/controller.js
+++ b/app/api/case/controller.js
@@ -98,7 +98,7 @@ exports.publishCases = async (req, res) => {
 
     const publicationParams = {
       organization_id: organization.id,
-      publish_date: Math.floor(new Date().getTime() / 1000),
+      publish_date: new Date(),
     };
     const publication = await publicationService.insert(publicationParams);
     if (publication) {

--- a/app/lib/publicationFiles.js
+++ b/app/lib/publicationFiles.js
@@ -104,7 +104,7 @@ class PublicationFiles {
     return {
       version: '1.0',
       name: organization.name,
-      publish_date_utc: record.publish_date.getTime() / 1000,
+      publish_date_utc: record.publish_date.getTime(),
       info_website_url: organization.infoWebsiteUrl,
       api_endpoint_url: organization.apiEndpointUrl,
       privacy_policy_url: organization.privacyPolicyUrl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -551,6 +551,8 @@
     },
     "@pathcheck/safeplaces-auth": {
       "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@pathcheck/safeplaces-auth/-/safeplaces-auth-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-U0hE+BmzEWTAt4AivWmqo6HYqfAGyp12mQArvceKAmy/PITPg5/ZeiQ/VMYouc5aAi462cyk8W5RlE/QZp/8Jw==",
       "requires": {
         "ajv": "^6.12.3",
         "jsonwebtoken": "^8.5.1",
@@ -11322,9 +11324,9 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vfile": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
-      "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+      "integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",

--- a/test/integration/case.test.js
+++ b/test/integration/case.test.js
@@ -245,12 +245,12 @@ describe('Case', () => {
       // Create two cases that have been published.
       await mockData.mockCaseAndTrails(
         _.extend(params, {
-          publishedOn: new Date().getTime() - 86400 * 5 * 1000,
+          publishedOn: new Date(new Date().getTime() - 86400 * (5 * 1000)),
         }),
       ); // Published 5 days ago
       await mockData.mockCaseAndTrails(
         _.extend(params, {
-          publishedOn: new Date().getTime() - 86400 * 2 * 1000,
+          publishedOn: new Date(new Date().getTime() - 86400 * (2 * 1000)),
         }),
       ); // Published 2 days ago
 

--- a/test/lib/mockData.js
+++ b/test/lib/mockData.js
@@ -232,7 +232,7 @@ class MockData {
     if (!options.end_date) throw new Error('End Date must be provided');
 
     let params = {
-      publish_date: Math.floor(new Date().getTime() / 1000),
+      publish_date: new Date(),
     };
 
     const results = await publicationService.insert(_.extend(params, options));
@@ -307,7 +307,7 @@ class MockData {
     if (options.publishedOn) {
       const publicationParams = {
         organization_id: options.organization_id,
-        publish_date: Math.floor(options.publishedOn / 1000),
+        publish_date: options.publishedOn,
       };
       const publication = await publicationService.insert(publicationParams);
       await caseService.updateCasePublicationId(


### PR DESCRIPTION
Noticed this while documenting the publication flow. These timestamps don't parse correctly and I believe we've standardized on milliseconds instead of seconds since epoch.

Tests should pass after a new data-layer version is published once this PR is merged: https://github.com/Path-Check/safeplaces-data-layer/pull/12